### PR TITLE
Groupの部分テンプレート修正

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -7,7 +7,7 @@ class MessagesController < ApplicationController
 
   def create
     current_user.messages.create(message_params)
-    redirect_to to: 'index'
+    redirect_to group_messages_path
   end
 
   private

--- a/app/views/groups/_groups.html.haml
+++ b/app/views/groups/_groups.html.haml
@@ -13,5 +13,4 @@
         =link_to "/groups/#{group[:id]}/messages", class: "groups__list--title" do
           =group.name
         =link_to "/groups/#{group[:id]}/messages", class: "groups__list--top" do
-          -group.messages.each.with_index do |message,i|
-            = message.message if i == (group.messages.length-1)
+          = group.messages.pluck(:message).last.nil?  ?  "まだメッセージがありません。"  :  "#{group.messages.pluck(:message).last}"


### PR DESCRIPTION
# What
投稿後のリダイレクト先をprefixでの指定に修正

# Why
メッセージ投稿後にurlに「?to=index」が付くのを消すため
